### PR TITLE
feat: add consistent styles for sign up

### DIFF
--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
         display: ["Mazer"],
       },
       colors: {
-        "brand-pink": "#FFD8F4",
+        "brand-pink": "#F29ADA",
         "brand-background": "#FFF1F3",
         "brand-teal": "#83F2B3",
         "brand-purple": "#CB8FF2",

--- a/resources/tailwind.css
+++ b/resources/tailwind.css
@@ -48,7 +48,7 @@
 
   ul,
   ol {
-    @apply my-3 pl-10;
+    @apply pl-10 my-3;
   }
 
   body {
@@ -67,12 +67,15 @@
 
 @layer components {
   .btn {
-    @apply relative z-[1] rounded border-2 border-black bg-brand-background p-2 text-2xl font-bold text-black translate-x-2 translate-y-2 shadow-[1px_1px_#000] hover:shadow-[4px_4px_#000];
+    @apply z-[1] rounded border-2 border-black bg-brand-background p-2 text-2xl font-bold text-black drop-shadow-[2px_2px_0px_rgba(0,0,0,100)] hover:drop-shadow-[2px_2px_0px_rgba(242,154,218,100)] hover:border-brand-pink  hover:bg-black hover:bg-opacity-10;
+  }
+  .pink-input { 
+    @apply bg-brand-background rounded border-2 focus:ring-0 focus:ring-offset-0 focus:border-brand-pink focus:bg-brand-pink focus:bg-opacity-10  
   }
 }
 
 @layer utilities {
-  .link {
+   link {
     @apply text-blue-600 hover:underline;
   }
 }

--- a/src/com/spicy/home.clj
+++ b/src/com/spicy/home.clj
@@ -15,47 +15,36 @@
 (defn home-page [{:keys [recaptcha/site-key params] :as ctx}]
   (ui/page
    (assoc ctx ::ui/recaptcha true)
+   [:.container.max-w-md.mx-auto.mt-20
    (biff/form
     {:action "/auth/send-link"
      :id "signup"
      :hidden {:on-error "/"}}
     (biff/recaptcha-callback "submitSignup" "signup")
-    [:h2.text-2xl.font-bold (str "Sign up for " settings/app-name)]
-    [:.h-3]
-    [:.flex
-     [:input#email {:name "email"
+    [:h2.text-2xl.font-bold.text-black (str "Sign up for " settings/app-name)]
+    [:.flex.flex-col.space-y-2.mt-8
+     [:input.pink-input#email {:name "email"
                     :type "email"
                     :autocomplete "email"
                     :placeholder "Enter your email address"}]
-     [:.w-3]
      [:button.btn.g-recaptcha
       (merge (when site-key
                {:data-sitekey site-key
                 :data-callback "submitSignup"})
              {:type "submit"})
-      "Sign up"]]
-    (when-some [error (:error params)]
-      [:<>
-       [:.h-1]
-       [:.text-sm.text-red-600
-        (case error
-          "recaptcha" (str "You failed the recaptcha test. Try again, "
-                           "and make sure you aren't blocking scripts from Google.")
-          "invalid-email" "Invalid email. Try again with a different address."
-          "send-failed" (str "We weren't able to send an email to that address. "
-                             "If the problem persists, try another address.")
-          "There was an error.")]])
-    [:.h-1]
-    [:.text-sm "Already have an account? " [:a.link {:href "/signin"} "Sign in"] "."]
+      "Sign up"]
+      ]
+    [:.mt-2.text-sm "Already have an account? " [:a.text-black.hover:text-brand-pink.font-bold {:href "/signin"} "Sign in"] "."]
     [:.h-3]
     biff/recaptcha-disclosure
-    email-disabled-notice)))
+    email-disabled-notice)]))
 
 (defn link-sent [{:keys [params] :as ctx}]
   (ui/page
    ctx
-   [:h2.text-xl.font-bold "Check your inbox"]
-   [:p "We've sent a sign-in link to " [:span.font-bold (:email params)] "."]))
+   [:.container.max-w-md.mx-auto.mt-20
+   [:h2.text-2xl.font-bold.text-black "Check your inbox"]
+   [:p "We've sent a sign-in link to " [:span.font-bold (:email params)] "."]]))
 
 (defn verify-email-page [{:keys [params] :as ctx}]
   (ui/page
@@ -85,15 +74,15 @@
 (defn signin-page [{:keys [recaptcha/site-key params] :as ctx}]
   (ui/page
    (assoc ctx ::ui/recaptcha true)
+    [:.container.max-w-md.mx-auto.mt-20
    (biff/form
     {:action "/auth/send-code"
      :id "signin"
      :hidden {:on-error "/signin"}}
     (biff/recaptcha-callback "submitSignin" "signin")
-    [:h2.text-2xl.font-bold "Sign in to " settings/app-name]
-    [:.h-3]
-    [:.flex
-     [:input#email {:name "email"
+    [:h2.text-2xl.font-bold.text-black (str "Sign in to " settings/app-name)]
+    [:.flex.flex-col.space-y-2.mt-8
+     [:input.pink-input#email {:name "email"
                     :type "email"
                     :autocomplete "email"
                     :placeholder "Enter your email address"}]
@@ -106,7 +95,6 @@
       "Sign in"]]
     (when-some [error (:error params)]
       [:<>
-       [:.h-1]
        [:.text-sm.text-red-600
         (case error
           "recaptcha" (str "You failed the recaptcha test. Try again, "
@@ -117,52 +105,54 @@
           "invalid-link" "Invalid or expired link. Sign in to get a new link."
           "not-signed-in" "You must be signed in to view that page."
           "There was an error.")]])
-    [:.h-1]
-    [:.text-sm "Don't have an account yet? " [:a.link {:href "/"} "Sign up"] "."]
+    [:.mt-2.text-sm "Don't have an account yet? " [:a.text-black.hover:text-brand-pink.font-bold {:href "/"} "Sign up"] "."]
     [:.h-3]
     biff/recaptcha-disclosure
-    email-disabled-notice)))
+    email-disabled-notice)]))
 
 (defn enter-code-page [{:keys [recaptcha/site-key params] :as ctx}]
   (ui/page
    (assoc ctx ::ui/recaptcha true)
-   (biff/form
-    {:action "/auth/verify-code"
-     :id "code-form"
-     :hidden {:email (:email params)}}
-    (biff/recaptcha-callback "submitCode" "code-form")
-    [:div [:label {:for "code"} "Enter the 6-digit code that we sent to "
-           [:span.font-bold (:email params)]]]
-    [:.h-1]
-    [:.flex
-     [:input#code {:name "code" :type "text"}]
-     [:.w-3]
-     [:button.btn.g-recaptcha
+   [:.container.max-w-md.mx-auto.mt-20
+    (biff/form
+      {:action "/auth/verify-code"
+      :id "code-form"
+      :hidden {:email (:email params)}}
+      (biff/recaptcha-callback "submitCode" "code-form")
+      [:div [:label {:for "code"} "Enter the 6-digit code that we sent to "
+            [:span.font-bold (:email params)]]]
+      [:.flex.flex-col.space-y-2.mt-8
+      [:input.pink-input#code {:name "code" :type "text"}]
+      [:.w-3]
+      [:button.btn.g-recaptcha
+        (merge (when site-key
+                {:data-sitekey site-key
+                  :data-callback "submitCode"})
+              {:type "submit"})
+        "Sign in"]])
+    (when-some [error (:error params)]
+      [:.h-1]
+      [:.text-sm.text-red-600
+        (case error
+          "invalid-code" "Invalid code."
+          "There was an error.")])
+    [:.h-3]
+    (biff/form
+      {:action "/auth/send-code"
+      :id "signin"
+      :hidden {:email (:email params)
+                :on-error "/signin"}}
+      (biff/recaptcha-callback "submitSignin" "signin")
+      [:button.text-black.hover:text-brand-pink.font-bold.g-recaptcha
       (merge (when site-key
-               {:data-sitekey site-key
-                :data-callback "submitCode"})
-             {:type "submit"})
-      "Sign in"]])
-   (when-some [error (:error params)]
-     [:.h-1]
-     [:.text-sm.text-red-600
-      (case error
-        "invalid-code" "Invalid code."
-        "There was an error.")])
-   [:.h-3]
-   (biff/form
-    {:action "/auth/send-code"
-     :id "signin"
-     :hidden {:email (:email params)
-              :on-error "/signin"}}
-    (biff/recaptcha-callback "submitSignin" "signin")
-    [:button.link.g-recaptcha
-     (merge (when site-key
-              {:data-sitekey site-key
-               :data-callback "submitSignin"})
-            {:type "submit"})
-     "Send another code"])))
-
+                {:data-sitekey site-key
+                :data-callback "submitSignin"})
+              {:type "submit"})
+      "Send another code"])
+    ]  
+  )
+)
+    
 (def plugin
   {:routes [["" {:middleware [mid/wrap-redirect-signed-in]}
              ["/"                  {:get home-page}]]

--- a/src/com/spicy/settings.clj
+++ b/src/com/spicy/settings.clj
@@ -1,3 +1,3 @@
 (ns com.spicy.settings)
 
-(def app-name "My Application")
+(def app-name "Spicy WOD")

--- a/src/com/spicy/ui.clj
+++ b/src/com/spicy/ui.clj
@@ -44,12 +44,13 @@
   [ctx & body]
   (base
     ctx
-    [:.p-3.mx-auto.max-w-screen-xl.w-full.flex.justify-between.items-center
-     [:.flex.items-center.gap-2
+    [:.p-3.mx-auto.max-w-screen-xl.w-full.flex.sm:justify-between.items-center.flex-wrap.space-y-2.justify-center
+     [:a.flex.items-center.gap-2
+      {:href "/"}
       [:img {:src "/img/spicywod-logo.png" :width 70 :height 70 :alt "spicy pepper"}]
       [:div {:class "font-display text-5xl w-[140px]"} "Spicy WOD"]]
      [:nav
-      [:ul.flex.list-none.gap-3
+      [:ul.flex.list-none.-ml-6.list-inside.gap-3
        [:li [:a.btn {:href "/app/workouts"} "Workouts"]]
        [:li [:a.btn {:href "/app/results"} "Scores"]]]]]
     [:.p-3.mx-auto.max-w-screen-xl.w-full


### PR DESCRIPTION
consistent styles for sign up/sign in flows.

loom walk through: https://www.loom.com/share/c29231e04fe342e9bc199f489c85e98d

![sign in](https://github.com/theianjones/spicy-wod/assets/6188161/c8b1748b-8372-42fd-b064-f50f2183c148)
![sign up](https://github.com/theianjones/spicy-wod/assets/6188161/27ab159e-9f44-4ab1-b9b9-b86bc17946f1)
![sign up mobile](https://github.com/theianjones/spicy-wod/assets/6188161/1902d0d1-c182-4ebb-b72a-9d6c084b2fba)
![check yo inbox](https://github.com/theianjones/spicy-wod/assets/6188161/a8499faf-2e93-436f-b8d4-ef5e95c4d6b6)
![6 digit code](https://github.com/theianjones/spicy-wod/assets/6188161/28702cbc-1f9e-485c-9d34-e12371d6ea3e)

![style](https://media.giphy.com/media/A7glKaSuRNd5lN0dJU/giphy-downsized.gif)
